### PR TITLE
Bugfix: Change queryStringParameters to HashMap

### DIFF
--- a/src/Aws/Lambda/Wai.hs
+++ b/src/Aws/Lambda/Wai.hs
@@ -114,10 +114,10 @@ takeRequestBodyChunk requestBodyMVar = do
     Just bs -> pure bs
     Nothing -> pure BS.empty
 
-toQueryStringParameters :: Maybe [(Text, Maybe Text)] -> [H.QueryItem]
-toQueryStringParameters (Just params@(p:ps)) =
-  let toQueryItem (key, valueMay) = (encodeUtf8 key, encodeUtf8 <$> valueMay)
-  in map toQueryItem params
+toQueryStringParameters :: Maybe (HMap.HashMap Text Text) -> [H.QueryItem]
+toQueryStringParameters (Just params) =
+  let toQueryItem (key, value) = (encodeUtf8 key, Just $ encodeUtf8 value)
+  in map toQueryItem $ HMap.toList params
 toQueryStringParameters _ = []
 
 parseIp :: Maybe Text -> IO Socket.SockAddr

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,8 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-- aws-lambda-haskell-runtime-3.0.0
+- github: andys8/aws-lambda-haskell-runtime
+  commit: ab684e43d9e5abf285c488e5af4912c0a1b0dd43
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,16 @@
 
 packages:
 - completed:
-    hackage: aws-lambda-haskell-runtime-3.0.0@sha256:1de27f1a3bdb85da3ebbc8a4f424c70fc72015c25cd22b13b79f4fa8dace30ff,3015
+    size: 30243
+    url: https://github.com/andys8/aws-lambda-haskell-runtime/archive/ab684e43d9e5abf285c488e5af4912c0a1b0dd43.tar.gz
+    name: aws-lambda-haskell-runtime
+    version: 3.0.1
+    sha256: 9620a334853ec6660fcfff6a7181ed273a4882bdaeb8717c6ddd6822332b8df9
     pantry-tree:
-      size: 1560
-      sha256: ce4852719b9a5e22d4d050b2e55a3e8b93a411e1ecf97d3a87ee46c705262f00
+      size: 3485
+      sha256: 9899dec0d6164e8d5aa464eff9acf7550f407607380c053722d5a975a6cc4802
   original:
-    hackage: aws-lambda-haskell-runtime-3.0.0
+    url: https://github.com/andys8/aws-lambda-haskell-runtime/archive/ab684e43d9e5abf285c488e5af4912c0a1b0dd43.tar.gz
 snapshots:
 - completed:
     size: 496120


### PR DESCRIPTION
## Issue

There is currently an issue with `aws-lambda-haskell-runtime` where query parameters are not working as expected. It leads to an `Aeson` crash.

https://github.com/theam/aws-lambda-haskell-runtime/issues/85

Therefore I propose this fix to `aws-lambda-haskell-runtime`.

https://github.com/theam/aws-lambda-haskell-runtime/pull/87

This library is currently using `aws-lambda-haskell-runtime` in version `3.0.0`. Because the fix is breaking the type signature, this PR is an update to adapt it.

It currently uses a fork of mine where the issue is fixed and the change is necessary. Once the upstream library is fixed and published, this PR can be adapted and merged.

Thanks for the wai library by the way 😌