### PR TITLE
Switch to aws-lambda-haskell-runtime 3.0.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -40,8 +40,7 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-- github: andys8/aws-lambda-haskell-runtime
-  commit: ab684e43d9e5abf285c488e5af4912c0a1b0dd43
+- aws-lambda-haskell-runtime-3.0.3
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,16 +5,12 @@
 
 packages:
 - completed:
-    size: 30243
-    url: https://github.com/andys8/aws-lambda-haskell-runtime/archive/ab684e43d9e5abf285c488e5af4912c0a1b0dd43.tar.gz
-    name: aws-lambda-haskell-runtime
-    version: 3.0.1
-    sha256: 9620a334853ec6660fcfff6a7181ed273a4882bdaeb8717c6ddd6822332b8df9
+    hackage: aws-lambda-haskell-runtime-3.0.3@sha256:ee7028412fc47fc40b07d59030461e229c75dbd336b7cca8bb045031497c2381,3015
     pantry-tree:
-      size: 3485
-      sha256: 9899dec0d6164e8d5aa464eff9acf7550f407607380c053722d5a975a6cc4802
+      size: 1560
+      sha256: e42aed32797952f60afbb2311641b47ae5037520f8d06060dd66469060787965
   original:
-    url: https://github.com/andys8/aws-lambda-haskell-runtime/archive/ab684e43d9e5abf285c488e5af4912c0a1b0dd43.tar.gz
+    hackage: aws-lambda-haskell-runtime-3.0.3
 snapshots:
 - completed:
     size: 496120


### PR DESCRIPTION
Fork not necessary anymore because the changes were merged upstream.

Relates to #4
Relates to <https://github.com/theam/aws-lambda-haskell-runtime/pull/87>